### PR TITLE
Expose stemcell updated time

### DIFF
--- a/ui/stemcell/stemcell.go
+++ b/ui/stemcell/stemcell.go
@@ -66,7 +66,7 @@ type StemcellSource struct {
 	MD5  string `json:"md5"`
 	SHA1 string `json:"sha1,omitempty"`
 
-	UpdatedAt string `json:"-"`
+	UpdatedAt string `json:"updated_at"`
 }
 
 type stemcellAPIRecord struct {


### PR DESCRIPTION
Allow API users to check stemcell update time. For example, useful for alerting on stale stemcells: https://github.com/cloudfoundry-community/prometheus-boshrelease/issues/84.

cc @frodenas