### PR TITLE
Add Deprecation Notice to Trusty Stemcells

### DIFF
--- a/templates/stemcells/_trusty_notice.tmpl
+++ b/templates/stemcells/_trusty_notice.tmpl
@@ -1,0 +1,4 @@
+<div class="admonition info">
+  <p class="admonition-title">Deprecation Warning</p>
+  <p>Stemcells based on Ubuntu Trusty (14.04) are no longer receiving security updates due to the end of upstream support. We strongly recommend switching to Ubuntu Xenial (16.04) based stemcells.</p>
+</div>

--- a/templates/stemcells/all.tmpl
+++ b/templates/stemcells/all.tmpl
@@ -31,8 +31,12 @@
         {{ range .DistroGroups }}
           <h2 id="{{ .Distro.NameName }}">{{ .Distro.Name }}<a class="headerlink" href="#{{ .Distro.NameName }}" title="Permanent link">&para;</a></h2>
 
-          {{ $os := ( index .Distro.OSMatches 0 ).OSName }}
-          {{ if (eq $os "windows") }}
+          {{ $osVersion := ( index .Distro.OSMatches 0 ).OSVersion }}
+          {{ if (eq $osVersion "trusty") }}
+            {{ template "stemcells/_trusty_notice" . }}
+          {{ end }}
+          {{ $osName := ( index .Distro.OSMatches 0 ).OSName }}
+          {{if (eq $osName "windows") }}
             {{ template "stemcells/_windows_notice" . }}
           {{ end }}
 


### PR DESCRIPTION
Trusty stemcells no longer receive security updates: https://lists.cloudfoundry.org/g/cf-bosh/message/2622