### PR TITLE
add sha256 to releases and stemcell api endpoints.

### DIFF
--- a/release/releasetarsrepo/concrete_release_tarballs_repository.go
+++ b/release/releasetarsrepo/concrete_release_tarballs_repository.go
@@ -65,9 +65,15 @@ func (r CRTRepository) Find(source, version string) (ReleaseTarballRec, error) {
 	for _, hash := range meta4.Files[0].Hashes {
 		if hash.Type == "sha-1" {
 			relTarRec.SHA1 = hash.Hash
-			return relTarRec, nil
+		}
+		if hash.Type == "sha-256" {
+			relTarRec.SHA256 = hash.Hash
 		}
 	}
 
-	return relTarRec, errors.New("Missing SHA1")
+	if relTarRec.SHA1 == "" {
+		return relTarRec, errors.New("Missing SHA1")
+	}
+
+	return relTarRec, nil
 }

--- a/release/releasetarsrepo/release_tarball.go
+++ b/release/releasetarsrepo/release_tarball.go
@@ -15,6 +15,7 @@ type ReleaseTarballRec struct {
 
 	BlobID string
 	SHA1   string
+	SHA256 string
 }
 
 func (r ReleaseTarballRec) ActualDownloadURL() (string, error) {

--- a/stemcell/stemsrepo/interfaces.go
+++ b/stemcell/stemsrepo/interfaces.go
@@ -15,6 +15,7 @@ type Stemcell interface {
 	Size() uint64
 	MD5() string
 	SHA1() string // could be empty
+	SHA256() string
 
 	InfName() string    // e.g. aws
 	HvName() string     // e.g. kvm

--- a/stemcell/stemsrepo/s3_stemcell.go
+++ b/stemcell/stemsrepo/s3_stemcell.go
@@ -27,9 +27,10 @@ type S3Stemcell struct {
 	version   semiver.Version
 	updatedAt string
 
-	size uint64
-	etag string
-	sha1 string
+	size   uint64
+	etag   string
+	sha1   string
+	sha256 string
 
 	infName    string // e.g. aws
 	hvName     string // e.g. kvm
@@ -43,7 +44,7 @@ type S3Stemcell struct {
 	url string
 }
 
-func NewS3Stemcell(key, etag, sha1 string, size uint64, lastModified, url string) *S3Stemcell {
+func NewS3Stemcell(key, etag, sha1 string, sha256 string, size uint64, lastModified, url string) *S3Stemcell {
 	m := matchS3FileKey(key)
 
 	if len(m) == 0 {
@@ -92,9 +93,10 @@ func NewS3Stemcell(key, etag, sha1 string, size uint64, lastModified, url string
 		version:   version,
 		updatedAt: lastModified,
 
-		size: size,
-		etag: strings.Trim(etag, "\""),
-		sha1: sha1,
+		size:   size,
+		etag:   strings.Trim(etag, "\""),
+		sha1:   sha1,
+		sha256: sha256,
 
 		infName:    m["inf_name"],
 		hvName:     m["hv_name"],
@@ -116,9 +118,10 @@ func (f S3Stemcell) Name() string { return f.name }
 func (f S3Stemcell) Version() semiver.Version { return f.version }
 func (f S3Stemcell) UpdatedAt() string        { return f.updatedAt }
 
-func (f S3Stemcell) Size() uint64 { return f.size }
-func (f S3Stemcell) MD5() string  { return f.etag }
-func (f S3Stemcell) SHA1() string { return f.sha1 }
+func (f S3Stemcell) Size() uint64   { return f.size }
+func (f S3Stemcell) MD5() string    { return f.etag }
+func (f S3Stemcell) SHA1() string   { return f.sha1 }
+func (f S3Stemcell) SHA256() string { return f.sha256 }
 
 func (f S3Stemcell) InfName() string    { return f.infName }
 func (f S3Stemcell) HvName() string     { return f.hvName }

--- a/stemcell/stemsrepo/s3_stemcell_test.go
+++ b/stemcell/stemsrepo/s3_stemcell_test.go
@@ -327,7 +327,7 @@ var _ = Describe("NewS3Stemcell", func() {
 		example := e
 
 		It(fmt.Sprintf("correctly interprets '%s'", path), func() {
-			s3Stemcell := NewS3Stemcell(path, "", "", 0, "", "")
+			s3Stemcell := NewS3Stemcell(path, "", "", "", 0, "", "")
 			Expect(s3Stemcell).ToNot(BeNil())
 
 			Expect(s3Stemcell.Name()).To(Equal(example.Name))

--- a/stemcell/stemsrepo/s3_stemcells_repository.go
+++ b/stemcell/stemsrepo/s3_stemcells_repository.go
@@ -25,9 +25,10 @@ type S3StemcellsRepository struct {
 }
 
 type s3StemcellRec struct {
-	Key  string
-	ETag string
-	SHA1 string
+	Key    string
+	ETag   string
+	SHA1   string
+	SHA256 string
 
 	Size         uint64
 	LastModified string
@@ -80,6 +81,7 @@ func (r S3StemcellsRepository) FindAll(name string) ([]Stemcell, error) {
 			rec.Key,
 			rec.ETag,
 			rec.SHA1,
+			rec.SHA256,
 			rec.Size,
 			rec.LastModified,
 			rec.URL,
@@ -151,7 +153,9 @@ func (r S3StemcellsRepository) loadIndex(dir string) ([]s3StemcellRec, error) {
 			for _, hash := range file.Hashes {
 				if hash.Type == "sha-1" {
 					rec.SHA1 = hash.Hash
-					break
+				}
+				if hash.Type == "sha-256" {
+					rec.SHA256 = hash.Hash
 				}
 			}
 

--- a/ui/release/release.go
+++ b/ui/release/release.go
@@ -45,8 +45,9 @@ type releaseAPIRecord struct {
 	Name    string `json:"name"`
 	Version string `json:"version"`
 
-	URL  string `json:"url"`
-	SHA1 string `json:"sha1"`
+	URL    string `json:"url"`
+	SHA1   string `json:"sha1"`
+	SHA256 string `json:"sha256,omitempty"`
 }
 
 type ReleaseSorting []Release
@@ -172,6 +173,15 @@ func (r Release) TarballSHA1() (string, error) {
 	return relTarRec.SHA1, nil
 }
 
+func (r Release) TarballSHA256() (string, error) {
+	relTarRec, err := r.relVerRec.Tarball()
+	if err != nil {
+		return "", err
+	}
+
+	return relTarRec.SHA256, nil
+}
+
 func (r *Release) NotesInMarkdown() (template.HTML, error) {
 	if r.notesInMarkdown == nil {
 		// Do not care about found -> no UI indicator
@@ -195,13 +205,18 @@ func (r Release) MarshalJSON() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	sha256, err := r.TarballSHA256()
+	if err != nil {
+		return nil, err
+	}
 
 	record := releaseAPIRecord{
 		Name:    r.Source.Full(),
 		Version: r.Version.AsString(),
 
-		URL:  r.UserVisibleDownloadURL(),
-		SHA1: sha1,
+		URL:    r.UserVisibleDownloadURL(),
+		SHA1:   sha1,
+		SHA256: sha256,
 	}
 
 	return json.Marshal(record)

--- a/ui/stemcell/stemcell.go
+++ b/ui/stemcell/stemcell.go
@@ -42,10 +42,11 @@ type StemcellSource struct {
 	isLight    bool
 	isForChina bool
 
-	URL  string `json:"url"`
-	Size uint64 `json:"size"`
-	MD5  string `json:"md5"`
-	SHA1 string `json:"sha1,omitempty"`
+	URL    string `json:"url"`
+	Size   uint64 `json:"size"`
+	MD5    string `json:"md5"`
+	SHA1   string `json:"sha1,omitempty"`
+	SHA256 string `json:"sha256,omitempty"`
 
 	UpdatedAt string `json:"-"`
 }
@@ -125,10 +126,11 @@ func (s *Stemcell) AddAsSource(s_ bhstemsrepo.Stemcell) {
 		hypervisorName:     hvName,
 		linkName:           linkName,
 
-		URL:  s_.URL(),
-		Size: s_.Size(),
-		MD5:  s_.MD5(),
-		SHA1: s_.SHA1(),
+		URL:    s_.URL(),
+		Size:   s_.Size(),
+		MD5:    s_.MD5(),
+		SHA1:   s_.SHA1(),
+		SHA256: s_.SHA256(),
 
 		UpdatedAt: s_.UpdatedAt(),
 	}
@@ -199,6 +201,13 @@ func (s Stemcell) SHA1() string {
 	return s.RegularSource.SHA1
 }
 
+func (s Stemcell) SHA256() string {
+	if s.LightSource != nil {
+		return s.LightSource.SHA256
+	}
+	return s.RegularSource.SHA256
+}
+
 func (s *Stemcell) NotesInMarkdown() (template.HTML, error) {
 	if s.notesInMarkdown == nil {
 		// Do not care about found -> no UI indicator
@@ -241,9 +250,11 @@ func (s StemcellSource) Ignored() bool {
 	return s.infrastructureName == "Amazon Web Services" && s.hypervisorName == "Xen"
 }
 
-func (s StemcellManifestNameSorting) Len() int           { return len(s) }
-func (s StemcellManifestNameSorting) Less(i, j int) bool { return s[i].ManifestName < s[j].ManifestName }
-func (s StemcellManifestNameSorting) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s StemcellManifestNameSorting) Len() int { return len(s) }
+func (s StemcellManifestNameSorting) Less(i, j int) bool {
+	return s[i].ManifestName < s[j].ManifestName
+}
+func (s StemcellManifestNameSorting) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 
 func (s StemcellVersionSorting) Len() int           { return len(s) }
 func (s StemcellVersionSorting) Less(i, j int) bool { return s[i].Version.IsLt(s[j].Version) }


### PR DESCRIPTION
adding sha256 to release and stemcell api endpoints if available
this can be used in combination with the bosh-io concourse resource
a pr for this will be created in a later stage