### PR TITLE
Escape release URL

### DIFF
--- a/ui/release/release.go
+++ b/ui/release/release.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
+	"net/url"
 
 	bprel "github.com/bosh-dep-forks/bosh-provisioner/release"
 	"github.com/bosh-io/web/ui/nav"
@@ -108,16 +109,16 @@ func (r Release) AllVersionsURL() string {
 func (r Release) AvatarURL() string { return r.relVerRec.AvatarURL() }
 
 func (r Release) URL() string {
-	return fmt.Sprintf("/releases/%s?version=%s", r.Source, r.Version)
+	return fmt.Sprintf("/releases/%s?version=%s", r.Source, url.QueryEscape(r.Version.AsString()))
 }
 
 func (r Release) DownloadURL() string {
-	return fmt.Sprintf("/d/%s?v=%s", r.Source, r.Version)
+	return fmt.Sprintf("/d/%s?v=%s", r.Source, url.QueryEscape(r.Version.AsString()))
 }
 
 func (r Release) UserVisibleDownloadURL() string {
 	// todo make domain configurable
-	return fmt.Sprintf("https://bosh.io/d/%s?v=%s", r.Source, r.Version)
+	return fmt.Sprintf("https://bosh.io/d/%s?v=%s", r.Source, url.QueryEscape(r.Version.AsString()))
 }
 
 func (r Release) UserVisibleLatestDownloadURL() string {


### PR DESCRIPTION
According to the semantic versioning + or - could be a part of the version, like _release_-_prerelease_+_build_metadata_. Escape the version in the URL in order to support signs like + or - .
Slack thread: https://cloudfoundry.slack.com/archives/C02HPPYQ2/p1680601152830719