### PR TITLE
url-encode release file names in CDN links

### DIFF
--- a/s3/cdn_signed_url.go
+++ b/s3/cdn_signed_url.go
@@ -9,6 +9,7 @@ import (
 	"encoding/base64"
 	"encoding/pem"
 	"errors"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -94,7 +95,7 @@ func (u CDNSignedURL) buildQuery() string {
 
 	// Headers can be passed in via query
 	if len(u.fileName) > 0 {
-		query = "response-content-disposition=attachment%3B%20filename%3D" + u.fileName
+		query = "response-content-disposition=attachment%3B%20filename%3D" + url.QueryEscape(u.fileName)
 	}
 
 	return "?" + query


### PR DESCRIPTION
In #56 we url-encode the file names on the bosh.io web interface. 

This PR applies the same url-encode when creating the desired download name (`content-disposition: attachment; filename=...`) instructions for the CDN. These instructions are passed to the CDN in as URL and are url-decoded by the CDN provider, but so far weren't url-encoded.
