### PR TITLE
url-encode of version for navigation to jobs and packages

### DIFF
--- a/ui/job/job.go
+++ b/ui/job/job.go
@@ -2,6 +2,7 @@ package job
 
 import (
 	"fmt"
+	"net/url"
 
 	bpreljob "github.com/bosh-dep-forks/bosh-provisioner/release/job"
 
@@ -41,7 +42,7 @@ func NewJob(j bpreljob.Job, rel bhrelui.Release) Job {
 }
 
 func (j Job) URL() string {
-	return fmt.Sprintf("/jobs/%s?source=%s&version=%s", j.Name, j.Release.Source, j.Release.Version)
+	return fmt.Sprintf("/jobs/%s?source=%s&version=%s", j.Name, j.Release.Source, url.QueryEscape(j.Release.Version.AsString()))
 }
 
 func (j Job) HasGithubURL() bool { return j.Release.HasGithubURL() }

--- a/ui/release/package.go
+++ b/ui/release/package.go
@@ -2,6 +2,7 @@ package release
 
 import (
 	"fmt"
+	"net/url"
 	"sort"
 
 	bprel "github.com/bosh-dep-forks/bosh-provisioner/release"
@@ -44,7 +45,7 @@ func NewPackages(ps []*bprel.Package, rel Release) []Package {
 }
 
 func (p Package) URL() string {
-	return fmt.Sprintf("/packages/%s?source=%s&version=%s", p.Name, p.Release.Source, p.Release.Version)
+	return fmt.Sprintf("/packages/%s?source=%s&version=%s", p.Name, p.Release.Source, url.QueryEscape(p.Release.Version.AsString()))
 }
 
 func (p Package) HasGithubURL() bool { return p.Release.HasGithubURL() }


### PR DESCRIPTION
Broken links: 
https://bosh.io/jobs/haproxy?source=github.com/cloudfoundry-incubator/haproxy-boshrelease&version=12.0.0+2.7.6
https://bosh.io/packages/haproxy?source=github.com/cloudfoundry-incubator/haproxy-boshrelease&version=12.0.0+2.7.6

Fix links for jobs and packages of the haproxy release version which is containing plus sign (for build metadata).