### PR TITLE
EOL message for bionic

### DIFF
--- a/templates/stemcells/_bionic_notice.tmpl
+++ b/templates/stemcells/_bionic_notice.tmpl
@@ -1,0 +1,4 @@
+<div class="admonition warning">
+  <p class="admonition-title">Deprecation Warning</p>
+  <p>Stemcells based on Ubuntu Bionic (18.04) are no longer receiving security updates from Open Source Cloud Foundry due to the End of Standard Support. We strongly recommend switching to Ubuntu Jammy (22.04) based stemcells.</p>
+</div>

--- a/templates/stemcells/_trusty_notice.tmpl
+++ b/templates/stemcells/_trusty_notice.tmpl
@@ -1,4 +1,4 @@
 <div class="admonition warning">
   <p class="admonition-title">Deprecation Warning</p>
-  <p>Stemcells based on Ubuntu Trusty (14.04) are no longer receiving security updates due to the end of upstream support. We strongly recommend switching to Ubuntu Bionic (18.04) based stemcells.</p>
+  <p>Stemcells based on Ubuntu Trusty (14.04) are no longer receiving security updates due to the end of upstream support. We strongly recommend switching to Ubuntu Jammy (22.04) based stemcells.</p>
 </div>

--- a/templates/stemcells/_xenial_notice.tmpl
+++ b/templates/stemcells/_xenial_notice.tmpl
@@ -1,4 +1,4 @@
 <div class="admonition warning">
   <p class="admonition-title">Deprecation Warning</p>
-  <p>Stemcells based on Ubuntu Xenial (16.04) are no longer receiving security updates from Open Source Cloud Foundry due to the End of Standard Support. We strongly recommend switching to Ubuntu Bionic (18.04) based stemcells.</p>
+  <p>Stemcells based on Ubuntu Xenial (16.04) are no longer receiving security updates from Open Source Cloud Foundry due to the End of Standard Support. We strongly recommend switching to Ubuntu Jammy (22.04) based stemcells.</p>
 </div>

--- a/templates/stemcells/all.tmpl
+++ b/templates/stemcells/all.tmpl
@@ -40,6 +40,9 @@
           {{ if (eq $osVersion "xenial") }}
             {{ template "stemcells/_xenial_notice" . }}
           {{ end }}
+          {{ if (eq $osVersion "bionic") }}
+            {{ template "stemcells/_bionic_notice" . }}
+          {{ end }}
           {{ if (eq $osVersion "jammy") }}
             {{ template "stemcells/_jammy_notice" . }}
           {{ end }}

--- a/templates/stemcells/single.tmpl
+++ b/templates/stemcells/single.tmpl
@@ -13,6 +13,9 @@
           {{ if (eq $s.OSVersion "xenial") }}
             {{ template "stemcells/_xenial_notice" . }}
           {{ end }}
+          {{ if (eq $s.OSVersion "bionic") }}
+            {{ template "stemcells/_bionic_notice" . }}
+          {{ end }}
           {{ if (eq $s.OSVersion "jammy") }}
             {{ template "stemcells/_jammy_notice" . }}
           {{ end }}


### PR DESCRIPTION
add a EOL message for bionic stemcells
as the official upstream bionic eol lifesycle is happening at the end of april 2022
https://ubuntu.com/about/release-cycle
https://endoflife.software/operating-systems/linux/ubuntu

the eol messages for trusty, xenial are also update to point to jammy